### PR TITLE
Remove an unnecessary file extension pattern from the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules
 dist
 .DS_Store
 server/public
-vite.config.ts.*
 *.tar.gz


### PR DESCRIPTION
Removes `vite.config.ts.*` from .gitignore as it's redundant and potentially harmful.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 427bfd43-3ad2-417b-b489-ce5522421a1a
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/9bf1c876-d2e0-4869-994f-0f7f52a235eb/427bfd43-3ad2-417b-b489-ce5522421a1a/6kkMalS